### PR TITLE
Remove Unnecessary AuthenticationManagerBuilder

### DIFF
--- a/nimbus-client/src/main/java/samples/oauth2/nimbus/client/config/SecurityConfig.java
+++ b/nimbus-client/src/main/java/samples/oauth2/nimbus/client/config/SecurityConfig.java
@@ -20,7 +20,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -68,16 +67,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 				.formLogin()
 					.and()
 				.addFilterBefore(authorizationCodeGrantFlowFilter(), UsernamePasswordAuthenticationFilter.class);
-	}
-	// @formatter:on
-
-	// @formatter:off
-	@Autowired
-	public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-		auth.authenticationProvider(openIDConnectAuthenticationProvider());
-//		auth
-//				.inMemoryAuthentication()
-//					.withUser("user").password("password").roles("USER");
 	}
 	// @formatter:on
 


### PR DESCRIPTION
If you expose an AuthenticationProvider as a Bean, you do not need to
use AuthenticationManagerBuilder